### PR TITLE
fix package name to include vendor

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.5)
-project(menge)
+project(menge_vendor)
 
 # Default to C99
 if(NOT CMAKE_C_STANDARD)
@@ -50,25 +50,25 @@ file(
 )
 
 add_library(
-	menge
+	menge_vendor
 	SHARED
 	${source_files}
 )
 
-target_include_directories( menge PUBLIC ${tinyxml_INCLUDE_DIRS} )
+target_include_directories( menge_vendor PUBLIC ${tinyxml_INCLUDE_DIRS} )
 
-target_link_libraries ( menge PUBLIC dl PRIVATE ${tinyxml_LIBRARIES} )
+target_link_libraries ( menge_vendor PUBLIC dl PRIVATE ${tinyxml_LIBRARIES} )
 
-set_target_properties( menge PROPERTIES LINKER_LANGUAGE CXX )
+set_target_properties( menge_vendor PROPERTIES LINKER_LANGUAGE CXX )
 
 include(GNUInstallDirs)
 
 ament_export_include_directories(include)
 
-ament_export_targets(menge HAS_LIBRARY_TARGET)
+ament_export_targets(menge_vendor HAS_LIBRARY_TARGET)
 
-install(TARGETS menge
-  EXPORT menge
+install(TARGETS menge_vendor
+  EXPORT menge_vendor
   DESTINATION lib
 )
 

--- a/package.xml
+++ b/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
-  <name>menge</name>
+  <name>menge_vendor</name>
   <version>1.0.0</version>
   <description>Menge is a powerful, cross-platform, modular framework for crowd simulation developed at the University of North Carolina - Chapel Hill. This package includes the core simulation part of origin menge package, with a bit modification for crowd simulation in gazebo and ignition gazebo.
   </description>


### PR DESCRIPTION
## Bug fix

### Fixed bug

Changing name `menge` to `menge_vendor` as per ROS releasing policies.